### PR TITLE
chore: set license in Cargo.toml

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -4,6 +4,7 @@ description = "Check whether the current time matches a condition passed via CLI
 version = "0.1.0"
 edition = "2021"
 rust-version = "1.67"
+license = "AGPL-3.0"
 
 [dependencies]
 anyhow = "1.0.75"


### PR DESCRIPTION
`cargo publish` failed without this..
