### PR TITLE
ci: Replace rust workflow with the rust-workflow

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -1,11 +1,24 @@
----
+name: Rust workflow
+
 on:
   push:
-    branches: [main]
-    tags: ['*']
+    branches: [ "main" ]
+    tags: [ "*" ]
   pull_request:
+    branches: [ "*" ]
+
+concurrency:
+  group: ${{ github.workflow }}-${{ github.ref }}
+  cancel-in-progress: true
 
 jobs:
-  build:
-    uses: famedly/github-workflows/.github/workflows/rust.yml@main
+  check:
+    permissions:
+      issues: write
+      pull-requests: write
+      contents: read
+    uses: famedly/backend-build-workflows/.github/workflows/rust-workflow.yml@tlater/breaking-changes
     secrets: inherit
+    with:
+      ref: tlater/breaking-changes
+      run-doctests: false


### PR DESCRIPTION
The original rust workflow has been superseded by the latter, and will be removed soon.